### PR TITLE
feat: Remove unnecessary use-client decorator

### DIFF
--- a/src/modules/todo-list/components/TodoItem/TodoItem.tsx
+++ b/src/modules/todo-list/components/TodoItem/TodoItem.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { FC, useMemo } from 'react';
 
 export interface Todo {


### PR DESCRIPTION
This PR removes an unnecessary `'use-client'` decorator from the `TodoItem` component file.