### PR TITLE
task: Refactor onItemChangeSuccess to accept updatedItem

### DIFF
--- a/src/modules/todo-list/components/TodoItem/TodoItem.tsx
+++ b/src/modules/todo-list/components/TodoItem/TodoItem.tsx
@@ -12,16 +12,12 @@ export interface Todo {
 }
 
 interface TodoItemProps extends Todo {
-  onItemChangeSuccess(id: string, isComplete: boolean): void;
+  onItemChangeSuccess(updatedItem: Todo): void;
 }
 
-const TodoItem: FC<TodoItemProps> = ({
-  id,
-  description,
-  isComplete,
-  dueDate,
-  onItemChangeSuccess,
-}) => {
+const TodoItem: FC<TodoItemProps> = ({ onItemChangeSuccess, ...item }) => {
+  const { id, description, isComplete, dueDate } = item;
+
   const [isProcessing, setIsProcessing] = useState(false);
 
   const { itemBgStyle, descriptionStyle } = useMemo(() => {
@@ -45,7 +41,10 @@ const TodoItem: FC<TodoItemProps> = ({
 
     updateTodo(id, !isComplete).then(({ status }) => {
       if (status === 'success') {
-        onItemChangeSuccess(id, !isComplete);
+        onItemChangeSuccess({
+          ...item,
+          isComplete: !isComplete,
+        });
       }
 
       setIsProcessing(false);

--- a/src/modules/todo-list/components/TodoList/TodoList.tsx
+++ b/src/modules/todo-list/components/TodoList/TodoList.tsx
@@ -15,16 +15,13 @@ const TodoList = () => {
     });
   }, []);
 
-  const onItemChangeSuccess = (id: string, isComplete: boolean) => {
+  const onItemChangeSuccess = (updatedItem: Todo) => {
     setTodos(
       (current) =>
         current &&
         current.map((todo) => {
-          if (todo.id === id) {
-            return {
-              ...todo,
-              isComplete,
-            };
+          if (todo.id === updatedItem.id) {
+            return updatedItem;
           }
 
           return todo;


### PR DESCRIPTION
This PR updates the `onItemChangeSuccess` method to accept the full `updatedItem: Todo` instead of separate `id` and `isComplete` props.